### PR TITLE
Replace hero portrait placeholder with actual image

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,9 @@
       </div>
       <div>
         <div class="portrait">
-          <div class="portrait-inner">Your Portrait Here</div>
+          <div class="portrait-inner">
+            <img class="portrait-img" src="d3GW56h.jpg" alt="Portrait of Twan Mulder" />
+          </div>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,7 @@ img{max-width:100%;display:block}
 .icon-row{display:flex;gap:.5rem;margin-left:.25rem}
 .portrait{border:1px solid rgba(0,0,0,.06);border-radius:24px;background:linear-gradient(to bottom,#fff,#f6f7fb);box-shadow:0 10px 30px rgba(2,12,27,.08);overflow:hidden;aspect-ratio:4/5;max-width:420px;margin:0 auto}
 .portrait-inner{height:100%;display:grid;place-items:center;color:#6b7280;font-size:.9rem}
+.portrait-img{width:100%;height:100%;object-fit:cover;display:block}
 
 /* Sections */
 .section{padding:3rem 0}


### PR DESCRIPTION
## Summary
- replace the hero placeholder block with an actual portrait image element
- add styling so the portrait scales to fill its container while maintaining aspect ratio

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da861dcfc8833185dfbb896fd4cab7