### PR TITLE
Improve hero text padding on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -46,8 +46,8 @@ img{max-width:100%;display:block}
 /* Hero */
 .hero{position:relative;border-bottom:1px solid var(--border)}
 .hero-bg{position:absolute;inset:0;max-width:1120px;margin:0 auto;height:540px;background:radial-gradient(40% 30% at 70% 0%, rgba(59,130,246,.25), transparent 70%),radial-gradient(40% 30% at 30% 0%, rgba(99,102,241,.25), transparent 70%);filter:blur(32px);z-index:-1}
-.hero-grid{display:grid;grid-template-columns:1fr;gap:2rem;padding:4rem 0 3rem}
-@media (min-width: 900px){.hero-grid{grid-template-columns:1.2fr .8fr;padding:6rem 0 4rem}}
+.hero-grid{display:grid;grid-template-columns:1fr;gap:2rem;padding:4rem 1.25rem 3rem}
+@media (min-width: 900px){.hero-grid{grid-template-columns:1.2fr .8fr;padding:6rem 1.25rem 4rem}}
 .eyebrow{font-size:.8rem;font-weight:700;letter-spacing:.18em}
 .blue{color:#0284c7}
 .display{font-size:clamp(2.25rem,5vw,3.25rem);line-height:1.15;margin:.4rem 0 .4rem;font-weight:800;letter-spacing:-.01em}


### PR DESCRIPTION
## Summary
- add horizontal padding back to the hero grid so text is spaced away from the screen edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8c13d82c8331af12af06bbd7b3b5