### PR TITLE
Highlight navigation links for active sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,6 +62,51 @@ function setupDarkMode() {
   btnM.addEventListener('click', update);
 }
 
+function setupScrollSpy() {
+  const sections = Array.from(document.querySelectorAll('section[id]')).filter(section => section.id !== 'home');
+  const nav = document.querySelector('.nav');
+  const navLinks = document.querySelectorAll('.nav-links a[href^="#"]');
+  const mobileLinks = document.querySelectorAll('.mobile-link[href^="#"]');
+  const linkMap = new Map();
+
+  const registerLink = link => {
+    const targetId = link.getAttribute('href').slice(1);
+    if (!targetId) return;
+    if (!linkMap.has(targetId)) linkMap.set(targetId, []);
+    linkMap.get(targetId).push(link);
+  };
+
+  navLinks.forEach(registerLink);
+  mobileLinks.forEach(registerLink);
+
+  const setActive = id => {
+    linkMap.forEach((links, key) => {
+      links.forEach(link => link.classList.toggle('active', key === id));
+    });
+  };
+
+  const updateActiveLink = () => {
+    const navOffset = (nav?.offsetHeight || 0) + 16;
+    const scrollPosition = window.scrollY + navOffset;
+    let activeId = null;
+
+    for (const section of sections) {
+      const top = section.offsetTop;
+      const bottom = top + section.offsetHeight;
+      if (scrollPosition >= top && scrollPosition < bottom) {
+        activeId = section.id;
+        break;
+      }
+    }
+
+    setActive(activeId);
+  };
+
+  window.addEventListener('scroll', updateActiveLink, { passive: true });
+  window.addEventListener('load', updateActiveLink);
+  updateActiveLink();
+}
+
 function downloadBibTeX(text, title) {
   try {
     const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
@@ -119,6 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
   personalize();
   setupMenu();
   setupDarkMode();
+  setupScrollSpy();
   initIcons();
   loadRepos();
 });

--- a/styles.css
+++ b/styles.css
@@ -22,8 +22,9 @@ img{max-width:100%;display:block}
 .brand{display:flex;align-items:center;gap:.6rem;font-weight:800;color:#111827}
 .brand-badge{height:32px;width:32px;border-radius:10px;background:linear-gradient(135deg,#38bdf8,#6366f1);box-shadow:0 2px 10px rgba(99,102,241,.25);display:block}
 .nav-links{display:none;align-items:center;gap:1rem}
-.nav-links a{color:#4b5563;font-weight:600}
+.nav-links a{color:#4b5563;font-weight:600;transition:color .2s ease}
 .nav-links a:hover{color:#111827}
+.nav-links a.active{color:#0284c7}
 .md-hide{display:inline-flex}
 @media (min-width: 768px){.nav-links{display:flex}.md-hide{display:none}}
 .icon-btn{display:inline-flex;align-items:center;justify-content:center;border:1px solid rgba(0,0,0,.06);padding:.5rem;border-radius:12px;background:#fff}
@@ -43,6 +44,7 @@ img{max-width:100%;display:block}
 .mobile-inner{max-width:1120px;margin:0 auto;padding:.75rem 1.25rem;display:flex;flex-direction:column;gap:.5rem}
 .mobile-link{padding:.75rem 1rem;border-radius:12px}
 .mobile-link:hover{background:#f8fafc}
+.mobile-link.active{color:#0284c7;font-weight:700}
 .hr{height:1px;background:#eef2f7;margin:.25rem 0}
 .mobile-actions{display:flex;align-items:center;justify-content:space-between;padding:.25rem .5rem}
 


### PR DESCRIPTION
## Summary
- add scroll spy logic to highlight navigation links when their sections are in view
- style desktop and mobile navigation links to adopt the blue accent when active

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da971245e08331b8a2ca5f93621b28