### PR TITLE
Add education section to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       <nav class="nav-links" id="navLinks">
         <a href="#about">About</a>
         <a href="#experience">Experience</a>
+        <a href="#education">Education</a>
         <a href="#projects">Projects</a>
         <a href="#writing">Writing</a>
         <a href="#publications">Publications</a>
@@ -45,6 +46,7 @@
       <div class="mobile-inner">
         <a href="#about" class="mobile-link">About</a>
         <a href="#experience" class="mobile-link">Experience</a>
+        <a href="#education" class="mobile-link">Education</a>
         <a href="#projects" class="mobile-link">Projects</a>
         <a href="#writing" class="mobile-link">Writing</a>
         <a href="#publications" class="mobile-link">Publications</a>
@@ -137,6 +139,31 @@
           </ul>
         </li>
       </ol>
+    </div>
+  </section>
+
+  <!-- EDUCATION -->
+  <section id="education" class="section alt">
+    <div class="wrap">
+      <h2 class="h2">Education</h2>
+      <div class="cards">
+        <article class="card">
+          <h3 class="h3">MSc Quantitative Finance · University of Amsterdam</h3>
+          <p class="meta">2020 — 2021</p>
+          <ul class="ul">
+            <li>Specialized in empirical asset pricing, derivatives, and machine learning for finance.</li>
+            <li>Thesis: “Robust factor timing with grouped heterogeneity signals.”</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3 class="h3">BSc Econometrics &amp; Operations Research · Erasmus University</h3>
+          <p class="meta">2016 — 2020</p>
+          <ul class="ul">
+            <li>Focused on time-series econometrics, optimization, and statistical computing.</li>
+            <li>Graduated cum laude with honors in quantitative finance coursework.</li>
+          </ul>
+        </article>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add an Education link to the primary and mobile navigation menus
- create an Education section beneath Experience highlighting MSc and BSc programs

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68daa98937a48331b8e1d1cd9b47c1d1