### PR TITLE
Ensure contact button text stays black

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,8 @@ img{max-width:100%;display:block}
 .btn{display:inline-flex;align-items:center;gap:.5rem;border-radius:12px;padding:.65rem .95rem;font-weight:700;border:1px solid var(--border);background:#fff;color:#111827;transition:background .2s ease,color .2s ease,border-color .2s ease}
 .btn-light{background:#fff;color:#111827}
 .btn-light:hover{background:#f1f5f9}
+#contactBtn,#contactBtn:hover{color:#000}
+.dark #contactBtn,.dark #contactBtn:hover{color:#000}
 .nav-links .btn:hover{color:inherit}
 .btn-dark{background:#111827;color:#fff;border-color:transparent}
 .btn-dark:hover{background:#000}


### PR DESCRIPTION
## Summary
- keep the contact button text color fixed to black in both default and hover states
- ensure the styling also holds when dark mode is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe83aa034833196a5d3b7281cbef4