### PR TITLE
Fix contact button text color in dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,7 @@ img{max-width:100%;display:block}
 .btn-light{background:#fff;color:#111827}
 .btn-light:hover{background:#f1f5f9}
 #contactBtn,#contactBtn:hover{color:#000}
-.dark #contactBtn,.dark #contactBtn:hover{color:#000}
+.dark #contactBtn,.dark #contactBtn:hover{color:#fff}
 .nav-links .btn:hover{color:inherit}
 .btn-dark{background:#111827;color:#fff;border-color:transparent}
 .btn-dark:hover{background:#000}


### PR DESCRIPTION
## Summary
- adjust the dark theme override so the contact button text stays readable

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbe9714ffc8331982b91e090220566