### PR TITLE
Simplify project modal PDF references

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,21 +237,34 @@
         <article class="card">
           <h3 class="h3">Project One</h3>
           <p class="muted">Short description of the problem, your approach, and the outcome. Include metrics if possible.</p>
-          <a href="#" class="link blue">View <i data-lucide="arrow-right"></i></a>
+          <button type="button" class="link blue project-view" data-project-id="project-one">View <i data-lucide="arrow-right"></i></button>
         </article>
         <article class="card">
           <h3 class="h3">Project Two</h3>
           <p class="muted">What you built, who it was for, and why it mattered. Add a case study link.</p>
-          <a href="#" class="link blue">View <i data-lucide="arrow-right"></i></a>
+          <button type="button" class="link blue project-view" data-project-id="project-two">View <i data-lucide="arrow-right"></i></button>
         </article>
         <article class="card">
           <h3 class="h3">Open‑source Library</h3>
           <p class="muted">Explain the purpose and adoption. Mention stars/downloads if relevant.</p>
-          <a href="#" class="link blue">View <i data-lucide="arrow-right"></i></a>
+          <button type="button" class="link blue project-view" data-project-id="open-source-library">View <i data-lucide="arrow-right"></i></button>
         </article>
       </div>
     </div>
   </section>
+
+  <div class="modal" id="projectModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="projectModalTitle">
+    <div class="modal-dialog">
+      <button type="button" class="icon-btn modal-close" data-close-modal aria-label="Close project details">
+        <i data-lucide="x"></i>
+      </button>
+      <h3 class="h3" id="projectModalTitle"></h3>
+      <p class="body" id="projectModalDescription"></p>
+      <a id="projectModalPdf" class="btn btn-dark" href="#" target="_blank" rel="noreferrer">
+        <i data-lucide="file-text"></i> View PDF
+      </a>
+    </div>
+  </div>
 
   <!-- CONTACT -->
   <section id="contact" class="section alt">

--- a/script.js
+++ b/script.js
@@ -7,6 +7,23 @@ const SITE = {
   linkedin: 'trmulder',
   cv: 'CV - Twan Mulder.pdf',
 };
+const PROJECTS = {
+  'project-one': {
+    title: 'Project One',
+    description: 'A concise overview of the project. Summarize the problem you tackled, your methodology, and the measurable impact for stakeholders.',
+    pdf: SITE.cv,
+  },
+  'project-two': {
+    title: 'Project Two',
+    description: 'Detail the business or research challenge, highlight the core techniques you used, and mention any performance improvements or adoption metrics.',
+    pdf: SITE.cv,
+  },
+  'open-source-library': {
+    title: 'Open-source Library',
+    description: 'Explain the motivation behind the library, the ecosystem it supports, and how other developers use it today.',
+    pdf: SITE.cv,
+  },
+};
 // --------------------------------------------------
 
 function setYear() {
@@ -114,11 +131,74 @@ async function loadRepos() {
 
 function initIcons() { lucide.createIcons(); }
 
+function setupProjectModals() {
+  const modal = document.getElementById('projectModal');
+  if (!modal) return;
+  const titleEl = document.getElementById('projectModalTitle');
+  const descriptionEl = document.getElementById('projectModalDescription');
+  const pdfEl = document.getElementById('projectModalPdf');
+  const closeBtn = modal.querySelector('[data-close-modal]');
+  const triggers = document.querySelectorAll('.project-view');
+  let lastFocus = null;
+
+  const closeModal = () => {
+    modal.classList.remove('open');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('modal-open');
+    if (lastFocus) {
+      lastFocus.focus({ preventScroll: true });
+      lastFocus = null;
+    }
+  };
+
+  const openModal = id => {
+    const project = PROJECTS[id];
+    if (!project) return;
+    titleEl.textContent = project.title;
+    descriptionEl.textContent = project.description;
+    const hasPdf = Boolean(project.pdf);
+    if (hasPdf) {
+      pdfEl.href = project.pdf;
+      pdfEl.removeAttribute('aria-disabled');
+      pdfEl.classList.remove('is-hidden');
+      pdfEl.setAttribute('aria-label', `Open ${project.title} PDF`);
+    } else {
+      pdfEl.removeAttribute('href');
+      pdfEl.setAttribute('aria-disabled', 'true');
+      pdfEl.classList.add('is-hidden');
+    }
+    modal.classList.add('open');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    lastFocus = document.activeElement;
+    (hasPdf ? pdfEl : closeBtn)?.focus({ preventScroll: true });
+  };
+
+  triggers.forEach(btn => {
+    btn.addEventListener('click', () => openModal(btn.dataset.projectId));
+  });
+
+  closeBtn?.addEventListener('click', closeModal);
+
+  modal.addEventListener('click', event => {
+    if (event.target === modal) {
+      closeModal();
+    }
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && modal.classList.contains('open')) {
+      closeModal();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   setYear();
   personalize();
   setupMenu();
   setupDarkMode();
   initIcons();
+  setupProjectModals();
   loadRepos();
 });

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,19 @@ img{max-width:100%;display:block}
 @media (min-width: 1024px){.cards{grid-template-columns:repeat(3,1fr)}}
 .card{border:1px solid rgba(0,0,0,.06);border-radius:16px;background:#fff;padding:1.1rem;box-shadow:0 6px 18px rgba(2,12,27,.05)}
 .card .link{display:inline-flex;align-items:center;gap:.35rem;font-weight:700}
+.card button.link{border:none;background:none;padding:0;font:inherit;color:inherit;cursor:pointer}
+.card button.link:focus-visible{outline:2px solid var(--primary);outline-offset:4px;border-radius:6px}
+
+/* Modal */
+.modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:1.5rem;background:rgba(11,15,20,.55);z-index:60}
+.modal.open{display:flex}
+.modal-dialog{position:relative;width:100%;max-width:460px;background:#fff;border-radius:20px;box-shadow:0 18px 48px rgba(15,19,24,.15);padding:2.25rem 2rem 1.75rem;display:flex;flex-direction:column;gap:1rem}
+.modal-close{position:absolute;top:1rem;right:1rem}
+body.modal-open{overflow:hidden}
+.modal .is-hidden{display:none}
+
+.dark .modal{background:rgba(0,0,0,.65)}
+.dark .modal-dialog{background:#0f1318;border:1px solid rgba(255,255,255,.12);box-shadow:0 18px 48px rgba(0,0,0,.35)}
 
 /* Writing list */
 .list-list{display:flex;flex-direction:column;gap:.75rem}


### PR DESCRIPTION
## Summary
- remove large placeholder project PDF binaries that blocked PR creation
- reuse the existing CV file as the default PDF for each project modal entry and guard against missing links in the UI
- hide the modal PDF button when no document is configured so the modal stays accessible

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de967509b48331b3fc062be8afbf60