### PR TITLE
Swap PDF and BibTeX button emphasis

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,10 +212,10 @@
           <p class="meta">Working Paper · 2025</p>
         </div>
         <div class="pub-actions">
-          <a href="#" class="btn btn-outline"><i data-lucide="file-text"></i> PDF</a>
+          <a href="#" class="btn btn-dark"><i data-lucide="file-text"></i> PDF</a>
           <a href="#" class="btn btn-outline"><i data-lucide="external-link"></i> SSRN</a>
           <a href="#" class="btn btn-outline"><i data-lucide="external-link"></i> arXiv</a>
-          <button class="btn btn-dark" onclick="downloadBibTeX(`@report{mulder2025mosaic,\n author={Mulder, Twan Richard},\n title={The Mosaic of Predictability for Corporate Bonds},\n type={Working paper},\n institution={University of Oxford},\n year={2025}\n}`, 'The Mosaic of Predictability for Corporate Bonds')"><i data-lucide="file-text"></i> BibTeX</button>
+          <button class="btn btn-outline" onclick="downloadBibTeX(`@report{mulder2025mosaic,\n author={Mulder, Twan Richard},\n title={The Mosaic of Predictability for Corporate Bonds},\n type={Working paper},\n institution={University of Oxford},\n year={2025}\n}`, 'The Mosaic of Predictability for Corporate Bonds')"><i data-lucide="file-text"></i> BibTeX</button>
         </div>
       </div>
 
@@ -226,8 +226,8 @@
           <p class="meta">Working Paper · 2024</p>
         </div>
         <div class="pub-actions">
-          <a href="sfcb.pdf" class="btn btn-outline"><i data-lucide="file-text"></i> PDF</a>
-          <button class="btn btn-dark" onclick="downloadBibTeX(`@report{mulder2024spectral,\n author={Mulder, Twan Richard and Grith, Maria and Verwijmeren, Patrick},\n title={Spectral Factor Model for Corporate Bonds: Separating Signal from Noise},\n type={Working paper},\n institution={Erasmus School of Economics},\n year={2024}\n}`, 'Spectral Factor Model for Corporate Bonds: Separating Signal from Noise')"><i data-lucide="file-text"></i> BibTeX</button>
+          <a href="sfcb.pdf" class="btn btn-dark"><i data-lucide="file-text"></i> PDF</a>
+          <button class="btn btn-outline" onclick="downloadBibTeX(`@report{mulder2024spectral,\n author={Mulder, Twan Richard and Grith, Maria and Verwijmeren, Patrick},\n title={Spectral Factor Model for Corporate Bonds: Separating Signal from Noise},\n type={Working paper},\n institution={Erasmus School of Economics},\n year={2024}\n}`, 'Spectral Factor Model for Corporate Bonds: Separating Signal from Noise')"><i data-lucide="file-text"></i> BibTeX</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make the PDF buttons use the dark button styling so they appear black in light mode
- switch the BibTeX buttons back to the outline styling to keep the emphasis on the PDFs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e25372c13c83318da2a9dd5d9c8153