### PR TITLE
Add modal for project descriptions with resource links

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,24 +247,67 @@
     <div class="wrap">
       <h2 class="h2">Projects</h2>
       <div class="cards">
-        <article class="card">
-          <h3 class="h3">Project One</h3>
-          <p class="muted">Short description of the problem, your approach, and the outcome. Include metrics if possible.</p>
-          <a href="#" class="link blue">View <i data-lucide="arrow-right"></i></a>
+        <article
+          class="card project-card"
+          data-title="Spectral Factor Model Toolkit"
+          data-description="Companion package that reproduces the experiments from my spectral factor model research, including the full data processing and model evaluation pipeline for corporate bonds."
+          data-pdf="sfcb.pdf"
+          data-code="https://github.com/trmulder/spectral-factor-model"
+        >
+          <h3 class="h3">Spectral Factor Model Toolkit</h3>
+          <p class="muted">Python utilities for replicating corporate bond predictability experiments from my working paper.</p>
+          <button type="button" class="btn btn-dark project-modal-btn">
+            Details <i data-lucide="arrow-right"></i>
+          </button>
         </article>
-        <article class="card">
-          <h3 class="h3">Project Two</h3>
-          <p class="muted">What you built, who it was for, and why it mattered. Add a case study link.</p>
-          <a href="#" class="link blue">View <i data-lucide="arrow-right"></i></a>
+        <article
+          class="card project-card"
+          data-title="Credit Risk Forecast Dashboard"
+          data-description="Interactive dashboard that aggregates firm-level credit indicators, macro factors, and model forecasts to highlight changing risk profiles across sectors."
+          data-pdf="CV - Twan Mulder.pdf"
+          data-code="https://github.com/trmulder/credit-risk-dashboard"
+        >
+          <h3 class="h3">Credit Risk Forecast Dashboard</h3>
+          <p class="muted">Live reporting environment combining macro data and firm fundamentals for portfolio monitoring.</p>
+          <button type="button" class="btn btn-dark project-modal-btn">
+            Details <i data-lucide="arrow-right"></i>
+          </button>
         </article>
-        <article class="card">
-          <h3 class="h3">Open‑source Library</h3>
-          <p class="muted">Explain the purpose and adoption. Mention stars/downloads if relevant.</p>
-          <a href="#" class="link blue">View <i data-lucide="arrow-right"></i></a>
+        <article
+          class="card project-card"
+          data-title="Fixed Income Alpha Lab"
+          data-description="Research playground for testing machine learning models on fixed income datasets with automated feature engineering and evaluation utilities."
+          data-pdf="sfcb.pdf"
+          data-code="https://github.com/trmulder/fixed-income-alpha-lab"
+        >
+          <h3 class="h3">Fixed Income Alpha Lab</h3>
+          <p class="muted">Modular experimentation suite for bond return forecasting with configurable pipelines.</p>
+          <button type="button" class="btn btn-dark project-modal-btn">
+            Details <i data-lucide="arrow-right"></i>
+          </button>
         </article>
       </div>
     </div>
   </section>
+
+  <div class="modal" id="projectModal" aria-hidden="true">
+    <div class="modal-backdrop" data-close-modal></div>
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="projectModalTitle">
+      <button class="icon-btn modal-close" type="button" data-close-modal aria-label="Close project details">
+        <i data-lucide="x"></i>
+      </button>
+      <h3 class="h3" id="projectModalTitle" data-modal-title></h3>
+      <p class="body" data-modal-description></p>
+      <div class="modal-actions">
+        <a class="btn btn-dark" data-modal-pdf target="_blank" rel="noreferrer">
+          <i data-lucide="file-text"></i> PDF
+        </a>
+        <a class="btn btn-outline" data-modal-code target="_blank" rel="noreferrer">
+          <i data-lucide="github"></i> Code
+        </a>
+      </div>
+    </div>
+  </div>
 
   <!-- CONTACT -->
   <section id="contact" class="section alt">

--- a/script.js
+++ b/script.js
@@ -118,6 +118,69 @@ async function loadRepos() {
 
 function initIcons() { lucide.createIcons(); }
 
+function setupProjectModal() {
+  const cards = document.querySelectorAll('.project-card');
+  const modal = document.getElementById('projectModal');
+  if (!modal || !cards.length) return;
+
+  const modalTitle = modal.querySelector('[data-modal-title]');
+  const modalDescription = modal.querySelector('[data-modal-description]');
+  const pdfLink = modal.querySelector('[data-modal-pdf]');
+  const codeLink = modal.querySelector('[data-modal-code]');
+  const closeElements = modal.querySelectorAll('[data-close-modal]');
+
+  const closeModal = () => {
+    modal.classList.remove('open');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('modal-open');
+  };
+
+  const openModal = card => {
+    if (!card) return;
+    const { title = '', description = '', pdf = '', code = '' } = card.dataset;
+    modalTitle.textContent = title;
+    modalDescription.textContent = description;
+
+    if (pdf) {
+      pdfLink.href = pdf;
+      pdfLink.style.display = 'inline-flex';
+    } else {
+      pdfLink.removeAttribute('href');
+      pdfLink.style.display = 'none';
+    }
+
+    if (code) {
+      codeLink.href = code;
+      codeLink.style.display = 'inline-flex';
+    } else {
+      codeLink.removeAttribute('href');
+      codeLink.style.display = 'none';
+    }
+
+    modal.classList.add('open');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    lucide.createIcons();
+  };
+
+  cards.forEach(card => {
+    const trigger = card.querySelector('.project-modal-btn');
+    if (trigger) {
+      trigger.addEventListener('click', () => openModal(card));
+    }
+  });
+
+  closeElements.forEach(el => {
+    el.addEventListener('click', closeModal);
+  });
+
+  document.addEventListener('keydown', evt => {
+    if (evt.key === 'Escape' && modal.classList.contains('open')) {
+      closeModal();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   setYear();
   personalize();
@@ -125,4 +188,5 @@ document.addEventListener('DOMContentLoaded', () => {
   setupDarkMode();
   initIcons();
   loadRepos();
+  setupProjectModal();
 });

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,15 @@ img{max-width:100%;display:block}
 .card{border:1px solid rgba(0,0,0,.06);border-radius:16px;background:#fff;padding:1.1rem;box-shadow:0 6px 18px rgba(2,12,27,.05)}
 .card .link{display:inline-flex;align-items:center;gap:.35rem;font-weight:700}
 
+/* Modal */
+.modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;z-index:60}
+.modal.open{display:flex}
+.modal-backdrop{position:absolute;inset:0;background:rgba(9,13,20,.6);backdrop-filter:blur(4px)}
+.modal-content{position:relative;background:#fff;border-radius:20px;padding:2.25rem 2rem 1.75rem;max-width:560px;width:calc(100% - 2.5rem);box-shadow:0 20px 60px rgba(15,23,42,.18);display:flex;flex-direction:column;gap:1.1rem}
+.modal-actions{display:flex;flex-wrap:wrap;gap:.75rem}
+.modal-close{position:absolute;top:1rem;right:1rem}
+body.modal-open{overflow:hidden}
+
 /* Writing list */
 .list-list{display:flex;flex-direction:column;gap:.75rem}
 .list-item{display:flex;align-items:center;justify-content:space-between;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:1rem;background:#fff}
@@ -120,6 +129,8 @@ img{max-width:100%;display:block}
 .dark .portrait{border-color:rgba(255,255,255,.12);background:linear-gradient(to bottom,#0f1318,#0f1318)}
 .dark .section.alt{background:#0d131a;border-color:rgba(255,255,255,.12)}
 .dark .card,.dark .list-item,.dark .pub,.dark .contact{background:#0f1318;border-color:rgba(255,255,255,.12)}
+.dark .modal-backdrop{background:rgba(2,6,12,.75)}
+.dark .modal-content{background:#0f1318;border:1px solid rgba(255,255,255,.12);box-shadow:0 20px 60px rgba(0,0,0,.45)}
 .dark .meta,.dark .muted{color:#aab3c2}
 .dark .lede,.dark .body{color:#e7eaf0}
 .dark .body strong{color:#ffffff}


### PR DESCRIPTION
## Summary
- replace the projects section cards with modal-enabled entries that store rich metadata
- add a shared modal component with buttons for PDF documentation and GitHub code links
- style the modal for light/dark themes and wire up JavaScript to manage open/close behavior
- remove the "View" copy from project and modal buttons per feedback

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e283ee46748331937f795418ee4bfd