### PR TITLE
Adjust project detail buttons for light mode contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
         >
           <h3 class="h3">Spectral Factor Model Toolkit</h3>
           <p class="muted">Python utilities for replicating corporate bond predictability experiments from my working paper.</p>
-          <button type="button" class="btn btn-dark project-modal-btn">
+          <button type="button" class="btn project-modal-btn">
             Details <i data-lucide="arrow-right"></i>
           </button>
         </article>
@@ -269,7 +269,7 @@
         >
           <h3 class="h3">Credit Risk Forecast Dashboard</h3>
           <p class="muted">Live reporting environment combining macro data and firm fundamentals for portfolio monitoring.</p>
-          <button type="button" class="btn btn-dark project-modal-btn">
+          <button type="button" class="btn project-modal-btn">
             Details <i data-lucide="arrow-right"></i>
           </button>
         </article>
@@ -282,7 +282,7 @@
         >
           <h3 class="h3">Fixed Income Alpha Lab</h3>
           <p class="muted">Modular experimentation suite for bond return forecasting with configurable pipelines.</p>
-          <button type="button" class="btn btn-dark project-modal-btn">
+          <button type="button" class="btn project-modal-btn">
             Details <i data-lucide="arrow-right"></i>
           </button>
         </article>

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,8 @@ img{max-width:100%;display:block}
 .btn-light:hover{background:#f1f5f9}
 #contactBtn,#contactBtn:hover{color:#000}
 .dark #contactBtn,.dark #contactBtn:hover{color:#fff}
+.project-modal-btn{background:#fff;color:#111827}
+.project-modal-btn:hover{background:#f1f5f9}
 .nav-links .btn:hover{color:inherit}
 .btn-dark{background:#111827;color:#fff;border-color:transparent}
 .btn-dark:hover{background:#000}
@@ -123,6 +125,8 @@ body.modal-open{overflow:hidden}
 .dark .btn-light:hover{background:#131922}
 .dark .btn-outline:hover{background:#121821}
 .dark .btn-dark{background:#e7eaf0;color:#0c1117}
+.dark .project-modal-btn{background:#0f1318;color:#e7eaf0;border-color:rgba(255,255,255,.15)}
+.dark .project-modal-btn:hover{background:#131922}
 .dark .mobile-menu{background:#0f1318;border-bottom:1px solid rgba(255,255,255,.12)}
 .dark .mobile-link:hover{background:#111721}
 .dark .hero{border-color:rgba(255,255,255,.12)}


### PR DESCRIPTION
## Summary
- update project cards to use a neutral button style that stays white in daylight mode
- add dedicated styling so the detail buttons remain legible in light and dark themes

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e28e3f2d6c833192ac73e3cdfd9638