### PR TITLE
Adjust project modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,10 @@
         <i data-lucide="x"></i>
       </button>
       <h3 class="h3" id="projectModalTitle" data-modal-title></h3>
-      <p class="body" data-modal-description></p>
+      <div class="modal-body-text">
+        <p class="body modal-abstract-label"><strong>Abstract</strong></p>
+        <p class="body" data-modal-description></p>
+      </div>
       <div class="modal-actions">
         <a class="btn btn-dark" data-modal-pdf target="_blank" rel="noreferrer">
           <i data-lucide="file-text"></i> PDF

--- a/styles.css
+++ b/styles.css
@@ -93,7 +93,10 @@ img{max-width:100%;display:block}
 .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;z-index:60}
 .modal.open{display:flex}
 .modal-backdrop{position:absolute;inset:0;background:rgba(9,13,20,.6);backdrop-filter:blur(4px)}
-.modal-content{position:relative;background:#fff;border-radius:20px;padding:2.25rem 2rem 1.75rem;max-width:560px;width:calc(100% - 2.5rem);box-shadow:0 20px 60px rgba(15,23,42,.18);display:flex;flex-direction:column;gap:1.1rem}
+.modal-content{position:relative;background:#fff;border-radius:20px;padding:2.25rem 2rem 1.75rem;max-width:720px;width:calc(100% - 2.5rem);box-shadow:0 20px 60px rgba(15,23,42,.18);display:flex;flex-direction:column;gap:1.1rem}
+.modal-body-text{display:flex;flex-direction:column;gap:0}
+.modal-abstract-label{margin:0;font-weight:700}
+.modal-body-text [data-modal-description]{margin:0}
 .modal-actions{display:flex;flex-wrap:wrap;gap:.75rem}
 .modal-close{position:absolute;top:1rem;right:1rem}
 body.modal-open{overflow:hidden}


### PR DESCRIPTION
## Summary
- widen the project modal to provide more space for long project descriptions
- add a bold "Abstract" label immediately above the modal description content

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2c0f1d9608331964ba5c559db4756