### PR TITLE
Temporarily comment out Code and Projects sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
         <a href="#experience">Experience</a>
         <a href="#education">Education</a>
         <a href="#publications">Publications</a>
-        <a href="#code">Code</a>
-        <a href="#projects">Projects</a>
+        <!-- <a href="#code">Code</a> -->
+        <!-- <a href="#projects">Projects</a> -->
         <a href="#contact">Contact</a>
         <span class="divider"></span>
         <button class="icon-btn" id="themeBtn" aria-label="Toggle dark mode">
@@ -47,8 +47,8 @@
         <a href="#experience" class="mobile-link">Experience</a>
         <a href="#education" class="mobile-link">Education</a>
         <a href="#publications" class="mobile-link">Publications</a>
-        <a href="#code" class="mobile-link">Code</a>
-        <a href="#projects" class="mobile-link">Projects</a>
+        <!-- <a href="#code" class="mobile-link">Code</a> -->
+        <!-- <a href="#projects" class="mobile-link">Projects</a> -->
         <a href="#contact" class="mobile-link">Contact</a>
         <div class="hr"></div>
         <div class="mobile-actions">
@@ -232,6 +232,7 @@
   </section>
 
   <!-- CODE (GitHub) -->
+  <!--
   <section id="code" class="section alt">
     <div class="wrap">
       <h2 class="h2">Code</h2>
@@ -239,8 +240,10 @@
       <p id="repoStatus" class="small muted"></p>
     </div>
   </section>
+  -->
 
   <!-- PROJECTS -->
+  <!--
   <section id="projects" class="section">
     <div class="wrap">
       <h2 class="h2">Projects</h2>
@@ -306,6 +309,7 @@
       </div>
     </div>
   </div>
+  -->
 
   <!-- CONTACT -->
   <section id="contact" class="section alt">

--- a/script.js
+++ b/script.js
@@ -82,6 +82,7 @@ function downloadBibTeX(text, title) {
   }
 }
 
+/*
 // GitHub repos (sorted by stars, then updated)
 async function loadRepos() {
   const user = SITE.github;
@@ -115,9 +116,11 @@ async function loadRepos() {
     status.textContent = 'Failed to load GitHub repos: ' + e.message;
   }
 }
+*/
 
 function initIcons() { lucide.createIcons(); }
 
+/*
 function setupProjectModal() {
   const cards = document.querySelectorAll('.project-card');
   const modal = document.getElementById('projectModal');
@@ -180,6 +183,7 @@ function setupProjectModal() {
     }
   });
 }
+*/
 
 document.addEventListener('DOMContentLoaded', () => {
   setYear();
@@ -187,6 +191,6 @@ document.addEventListener('DOMContentLoaded', () => {
   setupMenu();
   setupDarkMode();
   initIcons();
-  loadRepos();
-  setupProjectModal();
+  // loadRepos();
+  // setupProjectModal();
 });


### PR DESCRIPTION
### Motivation
- Hide the `Code` and `Projects` content from the public site while keeping the markup available to re-enable later.
- Prevent the GitHub repo loader and project modal from running when their sections are hidden to avoid empty UI areas or potential JS errors.
- Keep changes non-destructive by commenting out code instead of removing it so the sections can be restored quickly.

### Description
- Commented out the `Code` and `Projects` nav links and mobile menu links in `index.html`.
- Commented out the entire `#code` section, the `#projects` section, and the project modal markup in `index.html` so they are hidden but preserved.
- Commented out the `loadRepos` function and `setupProjectModal` function in `script.js` and disabled their invocations in the `DOMContentLoaded` handler.
- Left all original markup and JS in place as comments so the features can be re-enabled by uncommenting.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a full-page screenshot via Playwright to verify the UI, which completed successfully and produced `artifacts/site.png`.
- Verified the site loads without invoking the repo loader or project modal by confirming the commented JS functions are not executed during `DOMContentLoaded` (observed in browser render run).
- No unit tests were added or run as this is a static HTML/JS toggle change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7669c8dc83319605e1d7086058e7)